### PR TITLE
Genereation of `run.sh` files for Cluster Pi  

### DIFF
--- a/configuration/config.xml
+++ b/configuration/config.xml
@@ -60,4 +60,28 @@
     <method>python</method>
     <location>Models.Fuelcell.fuelcell_mosaik:FuelCellSim</location>
   </row>
+  <row>
+    <index>10</index>
+    <model>Wind</model>
+    <method>connect</method>
+    <location>192.168.0.1:5123</location>
+  </row>
+  <row>
+    <index>11</index>
+    <model>PV</model>
+    <method>connect</method>
+    <location>192.168.0.2:5123</location>
+  </row>
+  <row>
+    <index>12</index>
+    <model>Load</model>
+    <method>connect</method>
+    <location>192.168.0.3:5123</location>
+  </row>
+  <row>
+    <index>13</index>
+    <model>Battery</model>
+    <method>connect</method>
+    <location>192.168.0.4:5123</location>
+  </row>
 </data>

--- a/configuration/create_runsh.py
+++ b/configuration/create_runsh.py
@@ -4,6 +4,8 @@ sim_config_ddf=pd.read_xml('config.xml')
 
 sim_config={row[1]:{row[2]:row[3]}for row in sim_config_ddf.values}
 
+print (sim_config)
+
 tosh=sim_config_ddf[sim_config_ddf['method']=='connect']
 
 run_path='./Desktop/illuminatorclient/configuration/runshfile/'

--- a/configuration/create_runsh.py
+++ b/configuration/create_runsh.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+sim_config_ddf=pd.read_xml('config.xml')
+
+sim_config={row[1]:{row[2]:row[3]}for row in sim_config_ddf.values}
+
+tosh=sim_config_ddf[sim_config_ddf['method']=='connect']
+
+run_path='./Desktop/illuminatorclient/configuration/runshfile/'
+run_model='/home/illuminator/Desktop/Final_illuminator'
+
+if not tosh.empty:
+    with open ('run.sh', 'w') as rsh:
+        rsh.write("#! /bin/bash")
+        for row in tosh.values:
+            ip_port=row[3].split(":")
+            rsh.write("\n"+"lxterminal -e ssh illuminator@"+ip_port[0]+" '"+run_path+"run"+row[1]+".sh "+ip_port[0]+" "+ip_port[1]+" "+run_model+"'&")
+
+
+
+
+

--- a/configuration/modelling-example.yaml
+++ b/configuration/modelling-example.yaml
@@ -1,0 +1,71 @@
+scenario:
+  name: "ExampleScenario" # in mosaik so called world
+  start_time: '2012-01-02 00:00:00' # ISO 8601 start time of the simulation
+  end_time: '2012-01-02 00:00:10' # duration in seconds 
+models: # list of models for the energy network
+- name: Battery1 # name for the model (must be unique)
+  type: Battery # name of the model registered in the Illuminator
+  inputs: 
+    input1: 0  # input-name: initial value, default value will be used if not defined
+  outputs: 
+    output1: 0 
+    output2: null
+  parameters: 
+    charge_power_max: 100
+    discharge_power_max: 200
+    soc_min: 0.1 
+    soc_max: 0.9 
+    capacity: 1000
+  states: 
+    initial_soc: 0.5
+  triggers:   # list of triggers for the of another model??. It must be an input, output or state of the model
+    - capacity
+    - soc_min
+  scenario_data: 'path/to/file' #path to the scenario data file for the model. This should be optional
+  method: 
+    type: connect     # can be python for local or connect for remote
+    location: null
+    connect_ip: 192.168.0.1
+    connect_port: 5123
+- name: Battery2
+  type: Battery # models can reuse the same type
+  inputs: 
+    input1: 0  # input-name: initial value, default value will be used if not defined
+  outputs: 
+    output1: 0 
+    output2: null
+  parameters: 
+    charge_power_max: 100
+  states: 
+    soc: 0.5  # initial value for the state, optional
+  method: 
+    type: connect     # can be python for local or connect for remote
+    location: null
+    connect_ip: 192.168.0.2
+    connect_port: 5123
+- name: PV1
+  type: PV
+  inputs: 
+    input1: 0  # input-name: initial value, default value will be used if not defined
+    input2: 0
+  outputs: 
+    output1: 0 
+  parameters: 
+    power_max: 100
+  states: 
+    initial_soc: 0.5
+  method: 
+    type: connect     # can be python for local or connect for remote
+    location: null
+    connect_ip: 192.168.0.3
+    connect_port: 5123
+connections:
+- from: Battery1.output2 # start model, pattern: model_name.output_name/input_name
+  to: PV1.input1 # end model
+- from: Battery2.output
+  to: PV1.input2
+monitor:  # a list of models, its inputs, output and states to be monitored and logged
+- Battery1.input1 # pattern model_name.state_name
+- Battery2.output1  # no duplicates allowed
+- PV1.soc # pattern model_name.state_name
+- PV1.output1

--- a/configuration/parse_yaml.py
+++ b/configuration/parse_yaml.py
@@ -11,9 +11,12 @@ for model in data['models']:
     model_type = model.get('type')
 
     method = model.get('method', {})
+    method_type = method.get('type')
+    location = method.get('location')
     connect_ip = method.get('connect_ip')
     connect_port = method.get('connect_port')
 
-    if connect_ip and connect_port:
-        print(f"lxterminal -e ssh illuminator@{connect_ip} '{run_path}run{model_type}.sh {connect_ip} {connect_port} {run_model}'&")
+    if method_type == 'connect':
+        if connect_ip and connect_port:
+            print(f"lxterminal -e ssh illuminator@{connect_ip} '{run_path}run{model_type}.sh {connect_ip} {connect_port} {run_model}'&")
 

--- a/configuration/parse_yaml.py
+++ b/configuration/parse_yaml.py
@@ -1,0 +1,19 @@
+import yaml
+
+# Open and load the YAML file
+with open('modelling-example.yaml', 'r') as _file:
+    data = yaml.safe_load(_file)
+
+run_path='./Desktop/illuminatorclient/configuration/runshfile/'
+run_model='/home/illuminator/Desktop/Final_illuminator'
+
+for model in data['models']:
+    model_type = model.get('type')
+
+    method = model.get('method', {})
+    connect_ip = method.get('connect_ip')
+    connect_port = method.get('connect_port')
+
+    if connect_ip and connect_port:
+        print(f"lxterminal -e ssh illuminator@{connect_ip} '{run_path}run{model_type}.sh {connect_ip} {connect_port} {run_model}'&")
+

--- a/configuration/run.sh
+++ b/configuration/run.sh
@@ -1,2 +1,29 @@
 #! /bin/bash
-lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2storage.sh'&
+#
+# Remove comment sign for the components needed and change the IP address to the correct address.
+#
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runBattery.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runController.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runEboiler.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runElectrolyser.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runElenetwork.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runExample.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runFuelcell.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2demand.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2network.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2product.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2storage.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2valves.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatdemand.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatnetwork.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatproduct.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatpump.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatpumpController.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatstorage.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHotwaterstorage.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHotwatertanksim.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runLoad.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runLoadinNetSim.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runPV.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runValves.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runWind.sh 192.168.0.2 5123'&

--- a/configuration/run.sh
+++ b/configuration/run.sh
@@ -1,29 +1,5 @@
 #! /bin/bash
-#
-# Remove comment sign for the components needed and change the IP address to the correct address.
-#
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runBattery.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runController.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runEboiler.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runElectrolyser.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runElenetwork.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runExample.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runFuelcell.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2demand.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2network.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2product.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2storage.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2valves.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatdemand.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatnetwork.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatproduct.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatpump.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatpumpController.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatstorage.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHotwaterstorage.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHotwatertanksim.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runLoad.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runLoadinNetSim.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runPV.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runValves.sh 192.168.0.2 5123'&
-#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runWind.sh 192.168.0.2 5123'&
+lxterminal -e ssh illuminator@192.168.0.1 './Desktop/illuminatorclient/configuration/runshfile/runWind.sh 192.168.0.1 5123 /home/illuminator/Desktop/Final_illuminator'&
+lxterminal -e ssh illuminator@192.168.0.2 './Desktop/illuminatorclient/configuration/runshfile/runPV.sh 192.168.0.2 5123 /home/illuminator/Desktop/Final_illuminator'&
+lxterminal -e ssh illuminator@192.168.0.3 './Desktop/illuminatorclient/configuration/runshfile/runLoad.sh 192.168.0.3 5123 /home/illuminator/Desktop/Final_illuminator'&
+lxterminal -e ssh illuminator@192.168.0.4 './Desktop/illuminatorclient/configuration/runshfile/runBattery.sh 192.168.0.4 5123 /home/illuminator/Desktop/Final_illuminator'&

--- a/configuration/run.sh.org
+++ b/configuration/run.sh.org
@@ -1,0 +1,29 @@
+#! /bin/bash
+#
+# Remove comment sign for the components needed and change the IP address to the correct address.
+#
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runBattery.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runController.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runEboiler.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runElectrolyser.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runElenetwork.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runExample.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runFuelcell.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2demand.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2network.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2product.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2storage.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runH2valves.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatdemand.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatnetwork.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatproduct.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatpump.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatpumpController.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHeatstorage.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHotwaterstorage.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runHotwatertanksim.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runLoad.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runLoadinNetSim.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runPV.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runValves.sh 192.168.0.2 5123'&
+#lxterminal -e ssh illuminator@192.168.0.2 './Desktop/Final_illuminator/runshfile/runWind.sh 192.168.0.2 5123'&

--- a/configuration/runshfile/runBattery.sh
+++ b/configuration/runshfile/runBattery.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Battery
+cd $3/Battery
 python battery_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runBattery.sh
+++ b/configuration/runshfile/runBattery.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 cd /home/illuminator/Desktop/Final_illuminator/Battery
-python battery_mosaik.py 131.180.210.8:5123 --remote
+python battery_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runController.sh
+++ b/configuration/runshfile/runController.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Controller
+python controller_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runController.sh
+++ b/configuration/runshfile/runController.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Controller
+cd $3/Controller
 python controller_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runEboiler.sh
+++ b/configuration/runshfile/runEboiler.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Eboiler
+cd $3/Eboiler
 python eboiler_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runEboiler.sh
+++ b/configuration/runshfile/runEboiler.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Eboiler
+python eboiler_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runElectrolyser.sh
+++ b/configuration/runshfile/runElectrolyser.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Electrolyser
+python electrolyser_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runElectrolyser.sh
+++ b/configuration/runshfile/runElectrolyser.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Electrolyser
+cd $3/Electrolyser
 python electrolyser_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runElenetwork.sh
+++ b/configuration/runshfile/runElenetwork.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Elenetwork
+python electricity_network_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runElenetwork.sh
+++ b/configuration/runshfile/runElenetwork.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Elenetwork
+cd $3/Elenetwork
 python electricity_network_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runExample.sh
+++ b/configuration/runshfile/runExample.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/LoadinNetSim/example
+python model_mosaikapi.py $1:$2 --remote

--- a/configuration/runshfile/runExample.sh
+++ b/configuration/runshfile/runExample.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/LoadinNetSim/example
+cd $3/LoadinNetSim/example
 python model_mosaikapi.py $1:$2 --remote

--- a/configuration/runshfile/runFuelcell.sh
+++ b/configuration/runshfile/runFuelcell.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Fuelcell
+cd $3/Fuelcell
 python fuelcell_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runFuelcell.sh
+++ b/configuration/runshfile/runFuelcell.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Fuelcell
+python fuelcell_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2demand.sh
+++ b/configuration/runshfile/runH2demand.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/H2demand
+cd $3/H2demand
 python h2demand_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2demand.sh
+++ b/configuration/runshfile/runH2demand.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/H2demand
+python h2demand_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2network.sh
+++ b/configuration/runshfile/runH2network.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/H2network
+python gas_network_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2network.sh
+++ b/configuration/runshfile/runH2network.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/H2network
+cd $3/H2network
 python gas_network_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2product.sh
+++ b/configuration/runshfile/runH2product.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/H2product
+cd $3/H2product
 python h2product_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2product.sh
+++ b/configuration/runshfile/runH2product.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/H2product
+python h2product_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2storage.sh
+++ b/configuration/runshfile/runH2storage.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/H2storage
+python h2storage_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2storage.sh
+++ b/configuration/runshfile/runH2storage.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/H2storage
+cd $3/H2storage
 python h2storage_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2valves.sh
+++ b/configuration/runshfile/runH2valves.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Valves
+cd $3/Valves
 python h2valve_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runH2valves.sh
+++ b/configuration/runshfile/runH2valves.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Valves
+python h2valve_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatdemand.sh
+++ b/configuration/runshfile/runHeatdemand.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatdemand
+cd $3/Heatdemand
 python qdemand_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatdemand.sh
+++ b/configuration/runshfile/runHeatdemand.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatdemand
+python qdemand_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatnetwork.sh
+++ b/configuration/runshfile/runHeatnetwork.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatnetwork
+cd $3/Heatnetwork
 python heat_network_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatnetwork.sh
+++ b/configuration/runshfile/runHeatnetwork.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatnetwork
+python heat_network_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatproduct.sh
+++ b/configuration/runshfile/runHeatproduct.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatproduct
+python qproduct_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatproduct.sh
+++ b/configuration/runshfile/runHeatproduct.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatproduct
+cd $3/Heatproduct
 python qproduct_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatpump.sh
+++ b/configuration/runshfile/runHeatpump.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatpump/heatpump
+cd $3/Heatpump/heatpump
 python Heat_Pump_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatpump.sh
+++ b/configuration/runshfile/runHeatpump.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatpump/heatpump
+python Heat_Pump_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatpumpController.sh
+++ b/configuration/runshfile/runHeatpumpController.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatpump/controller
+cd $3/Heatpump/controller
 python controller_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatpumpController.sh
+++ b/configuration/runshfile/runHeatpumpController.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatpump/controller
+python controller_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatstorage.sh
+++ b/configuration/runshfile/runHeatstorage.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatstorage
+python qstorage_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHeatstorage.sh
+++ b/configuration/runshfile/runHeatstorage.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatstorage
+cd $3/Heatstorage
 python qstorage_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHotwaterstorage.sh
+++ b/configuration/runshfile/runHotwaterstorage.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Hotwaterstorage
+python hotwaterstorage_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHotwaterstorage.sh
+++ b/configuration/runshfile/runHotwaterstorage.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Hotwaterstorage
+cd $3/Hotwaterstorage
 python hotwaterstorage_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHotwatertanksim.sh
+++ b/configuration/runshfile/runHotwatertanksim.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Heatpump/hotwatertanksim
+cd $3/Heatpump/hotwatertanksim
 python hotwatertank_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runHotwatertanksim.sh
+++ b/configuration/runshfile/runHotwatertanksim.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Heatpump/hotwatertanksim
+python hotwatertank_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runLoad.sh
+++ b/configuration/runshfile/runLoad.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Load
+cd $3/Load
 python load_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runLoad.sh
+++ b/configuration/runshfile/runLoad.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Load
+python load_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runLoadinNetSim.sh
+++ b/configuration/runshfile/runLoadinNetSim.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/LoadinNetSim
+cd $3/LoadinNetSim
 python mosaik-model.py $1:$2 --remote

--- a/configuration/runshfile/runLoadinNetSim.sh
+++ b/configuration/runshfile/runLoadinNetSim.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/LoadinNetSim
+python mosaik-model.py $1:$2 --remote

--- a/configuration/runshfile/runPV.sh
+++ b/configuration/runshfile/runPV.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/PV
+cd $3/PV
 python pv_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runPV.sh
+++ b/configuration/runshfile/runPV.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/PV
+python pv_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runValves.sh
+++ b/configuration/runshfile/runValves.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Valves
+cd $3/Valves
 python qvalve_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runValves.sh
+++ b/configuration/runshfile/runValves.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Valves
+python qvalve_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runWind.sh
+++ b/configuration/runshfile/runWind.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-cd /home/illuminator/Desktop/Final_illuminator/Wind
+cd $3/Wind
 python wind_mosaik.py $1:$2 --remote

--- a/configuration/runshfile/runWind.sh
+++ b/configuration/runshfile/runWind.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /home/illuminator/Desktop/Final_illuminator/Wind
+python wind_mosaik.py $1:$2 --remote


### PR DESCRIPTION
Enhancements to the code for running the Illuminator in a ClusterPi.
 
- Suggestion to declare Ip and port in the yaml file.
- A parser to extract Ip and port from yam file. The output of the parser is a follows:
 
```shell
joan@CCXMST3:/mnt/d/data/illuminator/Illuminator/configuration$ python3 parse_yaml.py
lxterminal -e ssh [illuminator@192.168.0.1](mailto:illuminator@192.168.0.1) './Desktop/illuminatorclient/configuration/runshfile/runBattery.sh 192.168.0.1 5123 /home/illuminator/Desktop/Final_illuminator'&
lxterminal -e ssh [illuminator@192.168.0.2](mailto:illuminator@192.168.0.2) './Desktop/illuminatorclient/configuration/runshfile/runBattery.sh 192.168.0.2 5123 /home/illuminator/Desktop/Final_illuminator'&
lxterminal -e ssh [illuminator@192.168.0.3](mailto:illuminator@192.168.0.3) './Desktop/illuminatorclient/configuration/runshfile/runPV.sh 192.168.0.3 5123 /home/illuminator/Desktop/Final_illuminator'&
```