### PR TITLE
Example Generate documentation from doc strings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,19 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path('..', 'src').resolve()))
+autodoc_mock_imports = ["arrow", 
+                        "lxml",
+                        "matplotlib",
+                        "paho-mqtt",
+                        "pandapower",
+                        "pandas",
+                        "mosaik"
+                        ]
+
 project = 'Illuminator'
 copyright = '2024, Illuminator Team'
 author = 'Illuminator Team'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,5 +33,8 @@ and the simulation engine is based on `Mosaik. <https://mosaik.offis.de/>`_
 
    developer/start
 
+.. toctree::
+   :maxdepth: 2
+   :caption: References:
 
-
+   references/models.rst

--- a/docs/references/models.rst
+++ b/docs/references/models.rst
@@ -1,0 +1,10 @@
+Illumator Models
+=====================
+
+.. autoclass:: illuminator.models.Battery.battery_model::BatteryModel
+   :members:
+   :undoc-members:  this not necessary when docstrings are written
+
+
+.. 
+    more about autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc


### PR DESCRIPTION
This is an example of how to use `autodoc` to generate documentation from doc string for Sphinx.
Once the the PRs with doc strings are merged, we can use this as an example to add more models to the `models.rst` file.

> The content of `models.rst` most be in reStructured text (Marckdown won't always be rendered properly)
If necessary, other parts of the source code can be documented in different `RST` files. 
