### PR TITLE
Added unit tests for the PV model and mosaik classes

### DIFF
--- a/tests/Models/PV/test_pv_model.py
+++ b/tests/Models/PV/test_pv_model.py
@@ -1,0 +1,319 @@
+import pytest
+import numpy as np
+import sys
+sys.path.append('src/illuminator/models/PV/')
+from pv_model import PV_py_model
+
+class TestPVModelMethods():
+    """
+    Unit tester for the PV model
+    """
+
+    def create_basic_PV_object(self):
+        """
+        Creates the PV object with some pre-set data.
+        This method was created to avoid boilerplate code.
+        """
+        # Independent variables
+        panel_data = {'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800, 'Power_output_at_STC': 250, 'peak_power': 600}
+        m_tilt = 14
+        m_az = 180
+        cap = 500
+        output_type = "power"
+        resolution = 15
+
+        # Dependent variable
+        return PV_py_model(panel_data, m_tilt, m_az, cap, output_type, resolution)
+
+
+    def test_constructor_happy_flow(self):
+        """
+        The expected __init__ constructor outcome when creating the class object when given all expected values.
+        """
+        # Independent variables
+        panel_data = {'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800, 'Power_output_at_STC': 250, 'peak_power': 600}
+        m_tilt = 14
+        m_az = 180
+        cap = 500
+        output_type = "power"
+        resolution = 15
+
+        # Expected outcomes
+        pv = PV_py_model(panel_data, m_tilt, m_az, cap, output_type, resolution)
+        assert pv.m_area == panel_data["Module_area"]
+        assert pv.NOCT == panel_data['NOCT']
+        assert pv.m_efficiency_stc == panel_data['Module_Efficiency']
+        assert pv.G_NOCT == panel_data['Irradiance_at_NOCT']
+        assert pv.P_STC == panel_data['Power_output_at_STC']
+        assert pv.peak_power == panel_data['peak_power']
+        assert pv.m_tilt == m_tilt
+        assert pv.m_az == m_az
+        assert pv.cap == cap
+        assert pv.output_type == output_type
+        assert pv.resolution == resolution
+        assert pv.time_interval == resolution / 60
+
+    def test_constructor_missing_parameters(self):
+        """
+        Tests the __init__ constructor when creating the class object when given no expected values.
+        """
+        with pytest.raises(TypeError):
+            pv = PV_py_model()
+
+    def test_sun_azimuth_happy_flow(self):
+        """
+        Test for getter method of self.sun_az variable
+        """
+        # Independent variables
+        pv = self.create_basic_PV_object()
+        pv.sun_az = -175.14
+
+        # Expected results
+        assert pv.sun_azimuth() == pv.sun_az
+
+    def test_sun_elevation_happy_flow(self):
+        """
+        Test for getter method of self.sun_el variable
+        """
+        # Independent variables
+        pv = self.create_basic_PV_object()
+        pv.sun_el = -15.5
+
+        # Expected results
+        assert pv.sun_elevation() == pv.sun_el
+
+    def test_aoi_happy_flow_positive_aoi(self, monkeypatch):
+        """
+        aoi method performs small computations.
+        Calculated value, with the given parameters, should be 0.03195
+        """
+        # Independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "sun_elevation", lambda: -15.5)
+        monkeypatch.setattr(pv, "sun_azimuth", lambda: -175.14)
+
+        # Expected results
+        expected_outcome = round(0.03195064, 5)
+        actual_outcome = round(float(pv.aoi()), 5)
+        assert actual_outcome == expected_outcome
+
+
+    def test_aoi_happy_flow_negative_aoi(self, monkeypatch):
+        """
+        aoi method performs small computations.
+        Calculated value, with the given parameters, should be 0
+        """
+        # Independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "sun_elevation", lambda: -2)
+        monkeypatch.setattr(pv, "sun_azimuth", lambda: -10)
+        pv.m_tilt = 1
+        pv.m_az = 10
+
+        # Expected results
+        expected_outcome = 0
+        actual_outcome = pv.aoi()
+        assert actual_outcome == expected_outcome
+
+    def test_diffused_irr_happy_flow(self):
+        """
+        diffused_irr performs some small computations.
+        Calculated value, with the given parameters, should be 0.98515
+        """
+        # Independent variables
+        pv = self.create_basic_PV_object()
+        pv.dhi = 1
+
+        # Expected outcomes
+        expected_value = 0.98515
+        assert round(pv.diffused_irr(), 5) == expected_value
+
+    def test_reflected_irr_happy_flow(self):
+        """
+        reflected_irr performs some small computations.
+        Calculated value, with the given parameters, should be -0.60000
+        """
+        # Independent mocked methods and variables
+        pv = self.create_basic_PV_object()
+        pv.svf = 4
+        pv.ghi = 1
+
+        # Expected outcome
+        expected_val = -0.60000
+        assert round(pv.reflected_irr(), 5) == expected_val
+
+
+    def test_direct_irr_happy_flow(self, monkeypatch):
+        """
+        direct_irr multiplies two values together.
+                Calculated value, with the given parameters, should be 10
+        """
+        # Independent mocked methods and variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "aoi", lambda: 1)
+        pv.dni = 10
+
+        # Expected outcome
+        expected_dirr = 10
+        assert pv.direct_irr() == expected_dirr
+
+    def test_total_irr_happy_flow(self, monkeypatch):
+        """
+        Total_irr calls three methods and adds their values together.
+                Calculated value, with the given parameters, should be 6
+        """
+        # Independent mocked methods and variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "diffused_irr", lambda: 1)
+        monkeypatch.setattr(pv, "reflected_irr", lambda: 2)
+        monkeypatch.setattr(pv, "direct_irr", lambda: 3)
+
+        # Expected outcome
+        expected_irr = 6
+        assert pv.total_irr() == expected_irr
+
+    def test_Temp_effect_happy_flow(self, monkeypatch):
+        """
+        Test for the temp_effect calculation.
+        Calculated value, with the given parameters, should be 0.20465
+        """
+        # Mocked methods and independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "total_irr", lambda: 0.30000)
+        pv.temp = 15.4
+        pv.ws = 5.0
+
+        # Dependent method and expected outcome
+        expected_temp_effect = 0.20465
+        assert round(pv.Temp_effect(),5) == expected_temp_effect
+    
+    @pytest.mark.skip(reason="Numpy divide is used for 0 division, which sets 0 division to -inf.")
+    def test_Temp_effect_zero_division_error(self, monkeypatch):
+        """
+        Test for the temp_effect calculation with `G_NOCT` being set to 0
+        """
+        # Mocked methods and independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "total_irr", lambda: 0.30000)
+        pv.temp = 15.4
+        pv.ws = 5.0
+
+        # G_NOCT value should never be zero
+        pv.G_NOCT = 0
+        # Dependent method and expected outcome
+        with pytest.raises(ZeroDivisionError):
+            test = pv.Temp_effect()
+        
+    def test_Temp_effect_zero_division_pass(self, monkeypatch):
+        """
+        Test for the temp_effect calculation with `G_NOCT` being set to 0
+        """
+        # Mocked methods and independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "total_irr", lambda: 0.30000)
+        pv.temp = 15.4
+        pv.ws = 5.0
+
+        # G_NOCT value should never be zero, however Numpy handles it by setting it to negative infinity
+        pv.G_NOCT = 0
+        # Dependent method and expected outcome
+        assert np.isinf(pv.Temp_effect())
+
+
+    def test_output_power_happy_flow(self, monkeypatch):
+        """
+        Output test with the **power** output type.
+        This happy flow sets `total_irr` value as 0.3 and `Temp_effect as 0.20465
+
+        Expected power output for these values should be 0.21395
+        """
+        # Mocked methods and independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "total_irr", lambda: 0.30000) # Letting pytest know what to return when `total_irr` is called
+        monkeypatch.setattr(pv, "Temp_effect", lambda: 0.20465)
+        pv.g_aoi = 0.30000
+        
+        # Dependend methods
+        output = pv.output()
+        output['pv_gen'] = round(output['pv_gen'], 5)
+
+        # With the given mocked attributes we expect the following value rounded to 5 decimals
+        assert output == {'pv_gen': 0.21395, 'total_irr': pv.g_aoi}
+        
+
+    def test_output_energy_happy_flow(self, monkeypatch):
+        """
+        Output test with the **power** output type.
+        This happy flow sets `total_irr` value as 0.3 and `Temp_effect as 0.20465
+
+        Expected power output for these values should be 0.21395
+        """
+        # Mocked methods and independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "total_irr", lambda: 0.30000)
+        monkeypatch.setattr(pv, "Temp_effect", lambda: 0.20465)
+        pv.g_aoi = 0.30000
+        pv.output_type = "energy"
+        
+        # Dependent methods
+        output = pv.output()
+        output['pv_gen'] = round(output['pv_gen'], 5)
+
+        # With the given mocked attributes we expect the following value rounded to 5 decimals
+        assert output == {'pv_gen': 0.05349, 'total_irr': pv.g_aoi}
+
+    def test_output_invalid_output_type(self, monkeypatch):
+        """
+        Output test with the **power** output type.
+        This happy flow sets `total_irr` value as 0.3 and `Temp_effect as 0.20465
+
+        Expected power output for these values should be 0.21395
+        """
+        # Mocked methods and independent variables
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "total_irr", lambda: 0.30000) # Letting pytest know what to return when `total_irr` is called
+        monkeypatch.setattr(pv, "Temp_effect", lambda: 0.20465)
+        pv.g_aoi = 0.30000
+        pv.output_type = "INVALID"
+
+        
+        # Dependend methods
+        with pytest.raises(NameError):
+            output = pv.output()
+
+
+    def test_connect_happy_flow(self, monkeypatch):
+        """
+        The connect method with an expected happy flow.
+        It is dependent on the `output` method, thus it must be mocked.
+        """
+        # Mocked methods
+        # Output does not influence the connect method, thus it's return value is irrelevant
+        pv = self.create_basic_PV_object()
+        monkeypatch.setattr(pv, "output", lambda: {})
+
+        # Independent variables
+        G_Gh, G_Dh, G_Bn, Ta, hs, FF, Az = 0.0, 0.0, 0.0, 15.4, -15.5, 5.0, -175.14
+
+        # Expected return value
+        assert pv.connect(G_Gh, G_Dh, G_Bn, Ta, hs, FF, Az) == {}
+
+        # Exepcted attributes set after pv.connect was called
+        assert pv.ghi == G_Gh
+        assert pv.dhi == G_Dh
+        assert pv.dni == G_Bn
+        assert pv.temp == Ta
+        assert pv.sun_el == hs
+        assert pv.ws == FF
+        assert pv.sun_az == Az
+
+    def test_connect_missing_parameters(self):
+        """
+        The connect method when given no expected values should return a type error
+        """
+        pv = self.create_basic_PV_object()
+        with pytest.raises(TypeError):
+            pv.connect()
+
+
+

--- a/tests/Models/PV/test_pv_model.py
+++ b/tests/Models/PV/test_pv_model.py
@@ -1,8 +1,6 @@
 import pytest
 import numpy as np
-import sys
-sys.path.append('src/illuminator/models/PV/')
-from pv_model import PV_py_model
+from illuminator.models.PV.pv_model import PV_py_model
 
 class TestPVModelMethods():
     """

--- a/tests/Models/PV/test_pv_mosaik.py
+++ b/tests/Models/PV/test_pv_mosaik.py
@@ -1,12 +1,8 @@
 import pytest
 import numpy as np
 import pandas as pd
-import sys
-sys.path.append('src/illuminator/models/PV/')
-from pv_model import PV_py_model
-from pv_mosaik import PvAdapter
-# src/illuminator/models/PV/pv_model.py
-# from pv_model import PV_py_model
+from illuminator.models.PV.pv_model import PV_py_model
+from illuminator.models.PV.pv_mosaik import PvAdapter
 
 class TestPVMosaikMethods():
     """

--- a/tests/Models/PV/test_pv_mosaik.py
+++ b/tests/Models/PV/test_pv_mosaik.py
@@ -1,0 +1,127 @@
+import pytest
+import numpy as np
+import pandas as pd
+import sys
+sys.path.append('src/illuminator/models/PV/')
+from pv_model import PV_py_model
+from pv_mosaik import PvAdapter
+# src/illuminator/models/PV/pv_model.py
+# from pv_model import PV_py_model
+
+class TestPVMosaikMethods():
+    """
+    Unit tester for the PV mosaik
+    """
+    
+    def create_basic_PV_object(self):
+        """
+        Creates the PV object with some pre-set data.
+        This method was created to avoid boilerplate code.
+        """
+        # Independent variables
+        panel_data = {'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800, 'Power_output_at_STC': 250, 'peak_power': 600}
+        m_tilt = 14
+        m_az = 180
+        cap = 500
+        output_type = "power"
+        resolution = 15
+
+        # Dependent variable
+        return PV_py_model(panel_data, m_tilt, m_az, cap, output_type, resolution)
+
+    def test_constructor_happy_flow(self):
+        """
+        Tests the constructor happy flow.
+        Relatively simple test which only checks if attributes were created
+        """
+        # Independent variables
+        pv = PvAdapter()
+
+        # Expected outcome
+        assert type(pv.meta) == dict # Its value is irrelevant
+        assert pv.eid_prefix == 'pv_'
+        assert pv.entities == pv.mods == pv._cache == {}  # all of these should be an empty dictionary
+
+    def test_init_happy_flow(self):
+        """
+        The mosaik init override function test.
+        Only creates and checks for a few extra attributes.
+        """
+        # Independent variables
+        pv = PvAdapter()
+        
+        # Expected outcomes
+        output = pv.init(sid=None, time_resolution=5)
+        assert pv.time_resolution == 5
+        assert pv.meta == output
+    
+    @pytest.mark.skip(reason="[WIP] This test is currently incomplete.")
+    def test_create_happy_flow(self, monkeypatch):
+        """
+        This test is currently being skipped due to its heavy dependency on the mosaik api.
+        """
+        # Independent variables and mocked methods
+        pv = PvAdapter()
+        num = 1 
+        model = "PVset"
+        sim_start = "2012-06-01 00:00:00"
+        # {'panel_data': {'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800, 'Power_output_at_STC': 250, 'peak_power': 600}, 'm_tilt': 14, 'm_az': 180, 'cap': 500, 'output_type': 'power'}
+        # model_params = {'panel_data': {'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800, 'Power_output_at_STC': 250, 'peak_power': 600}, 'm_tilt': 14, 'm_az': 180, 'cap': 500}
+        model_params = {
+            "panel_data" : {'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800, 'Power_output_at_STC': 250, 'peak_power': 600},
+            "m_tilt" : 14,
+            "m_az" : 180,
+            "cap" : 500,
+            "output_type" : "power",
+            "resolution" : 15
+        }
+        actual_entities = pv.create(num, model, sim_start, model_params)
+        expected_entities = [{'eid': 'pv_0', 'type': 'PVset'}]
+        
+        
+        
+        assert pv.start == pd.to_datetime(sim_start)
+        assert pv.entities['pv_0'] == {}
+        assert actual_entities == expected_entities
+    
+    def test_step_happy_flow(self, monkeypatch):
+        """
+        An implementation of the step happy flow.
+        None is expected as a return value, while the `self._cache` attribute gains a new value.
+        """
+        # Independent variables
+        time = 0
+        inputs = {'pv_0': {'G_Gh': {'CSVB-1.Solar_data_0': 0.0}, 'G_Dh': {'CSVB-1.Solar_data_0': 0.0}, 'G_Bn': {'CSVB-1.Solar_data_0': 0.0}, 'Ta': {'CSVB-1.Solar_data_0': 15.4}, 'hs': {'CSVB-1.Solar_data_0': -15.5}, 'FF': {'CSVB-1.Solar_data_0': 5.0}, 'Az': {'CSVB-1.Solar_data_0': -175.14}}}
+        max_advance = 899
+
+        # Independent objects and its attributes
+        pv = PvAdapter()
+        pv.start = pd.to_datetime("2012-06-01 00:00:00")
+        pv.time_resolution = 1
+        pv_model = self.create_basic_PV_object()
+        pv.entities = {'pv_0':pv_model}
+
+        # Mock function to use
+        def mock_connect(*args):
+            return 0
+
+        monkeypatch.setattr(pv_model, "connect", mock_connect)
+
+        # Expected outcome: No returns, _cache is what we have set it to
+        assert pv.step(time, inputs, max_advance) == None
+        assert pv._cache['pv_0'] == 0
+    
+    def test_get_data_happy_flow(self):
+        """
+        A relatively simple getter test.
+        Gets values from `self._cache` attribute
+        """
+        # Independent variables
+        output = {'pv_0': ['pv_gen', 'total_irr']}
+        pv = PvAdapter()
+        pv._cache = {'pv_0': {'pv_gen': 1.0, 'total_irr': 2.0}}
+        expected_dict = {'pv_0': {'pv_gen': 1.0, 'total_irr': 2.0}}
+
+        # Dependent variables and expected output
+        output_dict = pv.get_data(output)
+        assert output_dict == expected_dict


### PR DESCRIPTION
Contains unit tests for the following two files:
pv_model.py
pv_mosaik.py


Currently all tests pass. There are 2 skipped tests:

1. pv_model contains the `test_Temp_effect_zero_division_error` function which is skipped because the originally written function seems to unintentionally handle zero division errors.
2. pv_mosaik contains the `test_create_happy_flow` function which is skipped due to its dependency on the mosaik api, making it an integration test instead.

