### PR TITLE
Hotfix collection for ModelConstructor class

### DIFF
--- a/examples/adder_copy.yaml
+++ b/examples/adder_copy.yaml
@@ -25,7 +25,10 @@ models: # list of models for the energy network
     param1: "adding hundreds"
 connections:
 - from: Adder1.out1 # start model, pattern: model_name.output_name/input_name
-  to: Adder2.in1 # end model
+  to: Adder2.in1n # end model
+# TODO: Below is what Illuminator looks for, but is not valid. Needs to be fixed
+# - from: Adder1-0.hybrid_0.out1 
+#   to: Adder2-0.hybrid_0.in1 
 
 #monitor:  # a list of models, its inputs, output and states to be monitored and logged
 #- Adder2.out2 # pattern model_name.state_name

--- a/examples/adder_copy.yaml
+++ b/examples/adder_copy.yaml
@@ -1,0 +1,39 @@
+scenario:
+  name: "AddingNumbers" # in mosaik so called world
+  start_time: '2012-01-02 00:00:00' # ISO 8601 start time of the simulation
+  end_time: '2012-01-02 00:00:10' # duration in seconds 
+  time_resolution: 900 # time step in seconds. Defaults to 15 minutes (900 s)
+  results: './out.csv'
+models: # list of models for the energy network
+- name: Adder1 # name for the model (must be unique)
+  type: Adder # most match the class inheriting from IlluminatorConstructor
+  inputs: 
+    in1: 10  # input-name: initial value, default value will be used if not defined
+    in2: 20
+  outputs: 
+    out1: 0 
+  parameters: 
+    param1: "adding tens"
+- name: Adder2
+  type: Adder # models can reuse the same type
+  inputs: 
+    in1: 100  # input-name: initial value, default value will be used if not defined
+    in2: 200
+  outputs:
+    out1: 0
+  parameters: 
+    param1: "adding hundreds"
+connections:
+- from: Adder1.out1 # start model, pattern: model_name.output_name/input_name
+  to: Adder2.in1 # end model
+
+#monitor:  # a list of models, its inputs, output and states to be monitored and logged
+#- Adder2.out2 # pattern model_name.state_name
+monitor:
+  file: './out.csv' 
+  items:
+  - Adder2.out2
+
+
+
+

--- a/src/illuminator/builder/model.py
+++ b/src/illuminator/builder/model.py
@@ -167,12 +167,15 @@ class ModelConstructor(ABC, Simulator):
         # self.model = self.load_model_class(self.model_data['model_path'], self.model_data['model_type'])
         return self._model.simulator_meta
     
-    def create(self, num: int) -> List:
+    def create(self, num:int, model:str, **model_params) -> List[dict]: # This change is mandatory. It MUST contain num and model as parameters otherwise it receives an incorrect number of parameters
         """Creates an instance of the model"""
-        for i in range(num):
-            eid = f"{self._model.simulator_type.value}_{i}"
-            self.model_entities[eid] = self._model
-        return list(self.model_entities.keys())
+        new_entities = [] # See below why this was created
+        for i in range(num): # this seems ok
+            eid = f"{self._model.simulator_type.value}_{i}" # this seems ok
+            self.model_entities[eid] = self._model # this seems fine
+        # return list(self.model_entities.keys()) # I removed this bit for now. Create is expected to return a list of dictionaries
+            new_entities.append({'eid': eid, 'type': model})  # So basically, like this. Later on we can look into other alternatives if needed.
+        return new_entities
     
     def current_time(self): 
         """Returns the current time of the simulation"""

--- a/src/illuminator/cli/main.py
+++ b/src/illuminator/cli/main.py
@@ -7,7 +7,7 @@ import typer
 from typing_extensions import Annotated
 import illuminator.engine as engine
 from pathlib import Path
-from illuminator.cluster import build_runshfile
+# from illuminator.cluster import build_runshfile 
 from illuminator.schema.simulation import load_config_file
 
 APP_NAME = "illuminator"

--- a/src/illuminator/engine.py
+++ b/src/illuminator/engine.py
@@ -10,6 +10,7 @@ from mosaik.scenario import Entity as MosaikEntity
 from mosaik.scenario import World as MosaikWorld
 from datetime import datetime
 
+current_model = {}
 
 def create_world(sim_config: dict, time_resolution: int) -> MosaikWorld:
     """
@@ -156,6 +157,7 @@ def start_simulators(world: MosaikWorld, models: list) -> dict:
         for model in models:
             model_name = model['name']
             model_type = model['type']
+            set_current_model(model)
 
 
             if 'parameters' in model:
@@ -177,6 +179,8 @@ def start_simulators(world: MosaikWorld, models: list) -> dict:
             else:
                 simulator = world.start(sim_name=model_name,
                                     # **model_parameters
+                                    model_name = model_name,
+                                    sim_params= {model_name: model} # This value gets picked up in the init() function
                                     # Some items must be passed here, and some other at create()
                                     )
         
@@ -270,6 +274,16 @@ def compute_mosaik_end_time(start_time:str, end_time:str, time_resolution:int = 
 
     return steps
 
+# def get_current_model():
+#     return current_model
+
+def set_current_model(model):
+    global current_model
+    current_model["type"] = model['type']
+    current_model['parameters']=model['parameters']
+    current_model['inputs']=model["inputs"]
+    current_model['outputs']=model["outputs"]
+    
 
 def connect_monitor(world: MosaikWorld,  model_entities: dict[MosaikEntity], 
                     monitor:MosaikEntity, monitor_config: dict) -> MosaikWorld:

--- a/src/illuminator/engine.py
+++ b/src/illuminator/engine.py
@@ -196,14 +196,19 @@ def start_simulators(world: MosaikWorld, models: list) -> dict:
 
                 # TODO:
                 # this is a temporary solution to continue developing the CLI
-                entity = model_factory.create(num=1, sim_start='2012-01-01 00:00:00', 
-                                            panel_data={'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800,
-          'Power_output_at_STC': 250,'peak_power':600},
-                                            m_tilt=14, 
-                                            m_az=180, 
-                                            cap=500,
-                                            output_type='power'
-                                            )
+
+                # TODO: If we wish to use different values here, we must define the parameters used here within the appropriate .yaml file.
+                # Right now adder.yaml defines the custom parameters as "param1"
+                
+        #         entity = model_factory.create(num=1, sim_start='2012-01-01 00:00:00', 
+        #                                     panel_data={'Module_area': 1.26, 'NOCT': 44, 'Module_Efficiency': 0.198, 'Irradiance_at_NOCT': 800,
+        #   'Power_output_at_STC': 250,'peak_power':600},
+        #                                     m_tilt=14, 
+        #                                     m_az=180, 
+        #                                     cap=500,
+        #                                     output_type='power'
+        #                                     )
+            entity = model_factory.create(num=1, param1="Not in use") 
 
             model_entities[model_name] = entity
             print(model_entities)

--- a/src/illuminator/schema/simulation.py
+++ b/src/illuminator/schema/simulation.py
@@ -17,6 +17,7 @@ ipv4_pattern = r'^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$'
 # monitor and connections sections enforce a format such as 
 # <model>.<input/output/state>
 valid_model_item_format = r'^\w+\.\w+$'
+# valid_model_item_format = r'^([\w-]+\.?)+$' # This is kept here as an alternative. I believe this might be useful later on
 
 
 


### PR DESCRIPTION
### **Fixed:**

- Missing cluster import (temporary)
- Missing parameter in parent class ModelConstructor
- Incorrect sim_params length (this can be deleted since its unused)
- Incorrect number of parameters used for .create(...) functions.

### **Added:**

- Global dictionary current_model added to engine.py (alternative should be found and replace this implementation)
-- This variable is called when the mosaik.world.start is creating the appropriate child model
- Alternative (commented out) regex for yaml files. It might be useful later on during connection stage fixes.
- Alternative (commented out) naming convention for connections within adder_copy.yaml
- Proposed (within comments) fix for adding custom number of parameters for create function

### **TODO**
- ~Currently this implementation now enters the "create" stage of the simulation, and crashes due to unknown parameters.~
- Current implementation creates models as expected, however it fails on creating connections between them. Likely issue is invalid naming convention.
- Currently has following error:
`ScenarioError: While connecting entities, the following errors occurred:
The are problems connecting Adder1-0.hybrid_0.out1 to Adder2-0.hybrid_0.in1n: the destination attribute does not exist`