### PR TITLE
throwing error now if yaml file is not found or not in a wrong format

### DIFF
--- a/src/illuminator/schema/simulation.py
+++ b/src/illuminator/schema/simulation.py
@@ -42,15 +42,13 @@ def load_config_file(config_file: str, json:bool=False) -> dict | str:
         with open(config_file, 'r', encoding='utf-8') as _file:
             yaml = YAML(typ='safe')
             data = yaml.load(_file)
-    except FileNotFoundError:
-        print(f"Error: The file {config_file} was not found.")
-        return None
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"Config file '{config_file}' was not found.") from e
     
     try:
         valid_data = schema.validate(data)
     except SchemaUnexpectedTypeError as exc:
-        print(f"Error while parsing YAML file. \n Are you passing a file written in YAML?: {exc}")
-        return None
+        raise SchemaUnexpectedTypeError(f"Error while parsing YAML file. \n Are you passing a file written in YAML?: {exc}")
   
     if json:
         return json_module.dumps(valid_data, indent=4)


### PR DESCRIPTION
Throwing an actual error when it cannot find the yaml file or when it is in a format that we cannot parse