### PR TITLE
Small hotfix: updated a trigger for the website action

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,9 +1,8 @@
 name: Start docs update for website # Name of the whole Action. However when the job runs on github it will take the name of last Commit message.
 
 on: # run ON
-  push: # a PUSH action
-    branches: # on the branch:
-      - main
+  release: # a github release action
+    types: [published] # The relase must be of type PUBLISHED
   workflow_dispatch: # a MANUAL START action and on ANY branch since its NOT defined.
 
 


### PR DESCRIPTION
### **Changes:**
This should now mimic the same push behaviour as python-publish.yml
Meaning that instead of triggering on a push to MAIN it will trigger on a successful publishing.
It can still be triggered manually.

### **Reason for change:**
The website repository depends on the PyPI release of illuminator for it to automatically update its code documentation generated through sphinx's autodoc. This means that the current behaviour expects that whenever a PR is accepted into main, the administrator would also create a new illuminator release on github. This change would alter the trigger so that it would instead happen whenever a new release is created, which would mean there is less time-pressure on administrators to publish a new release.
