### PR TITLE
Update project dependencies to Python 3.14 and pandas 3.0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.14'
       - name: Install Pandoc
         uses: pandoc/actions/setup@v1
         with:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.14'
 
     - name: Install system dependencies
       run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,15 @@
-Sphinx==7.4.7
-myst-parser==3.0.1
-sphinx-copybutton==0.5.2
-sphinx-rtd-theme==2.0.0
-nbsphinx==0.9.5
-arrow==1.2.3
-lxml==4.9.3
-matplotlib==3.7.2
-paho-mqtt==1.6.1
-pandapower==2.13.1
-pandas==1.5.3
-mosaik>=3.3.3
-ruamel.yaml>= 0.18.5
-schema >= 0.7.0
-pandoc >= 2.4.0
-jupyterlab >= 4.3.0
+Sphinx>=7.4.7
+myst-parser>=3.0.1
+sphinx-copybutton>=0.5.2
+sphinx-rtd-theme>=2.0.0
+nbsphinx>=0.9.5
+arrow>=1.4.0
+lxml>=6.1.1
+matplotlib>=3.10.9
+paho-mqtt>=2.1.0
+pandas>=3.0.3
+mosaik>=3.6.0
+ruamel.yaml>=0.19.1
+schema>=0.7.7
+pandoc>=2.4.0
+jupyterlab>=4.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,18 +3,16 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - arrow=1.2.3
-  - lxml=4.9.3
-  - matplotlib=3.7.2
-  - paho-mqtt=1.6.1
-  - pandapower=2.13.1
-  - pandas=1.5.3
+  - arrow>=1.4.0
+  - lxml>=6.1.1
+  - matplotlib>=3.10.9
+  - paho-mqtt>=2.1.0
+  - pandas>=3.0.3
   - pip
-  - python>=3.11
-  - setuptools=68.0.0
+  - python>=3.14.5
+  - numpy>=2.3.5
   - pip:
-    - mosaik==3.3.3 
-    - mpi4py
-    - pytest
+    - mosaik>=3.6.0
+    - mpi4py>=4.1.2
+    - pytest>=9.0.3
     - illuminator>=3.0.0-alpha
-    # - mosaik-api==3.0.3 # If mosaik != 3.1.1 then - mosaik-api==3.0.3 is needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "3.1-beta.0"
 description = "A development toolkit for simulating energy systems"
 license = {file = "LICENSE"}
 readme = "readme.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 authors = [
     { name = "Jort Groen"},
     { name = "Despoina Kassandra Georgiadi"},
@@ -24,18 +24,17 @@ maintainers = [
     { name = "Illuminator Team", email = "illuminator@tudelft.nl"}
     ]
 dependencies = [
-    "arrow==1.2.3",
-    "lxml==4.9.3",
-    "matplotlib==3.7.2",
-    "paho-mqtt==1.6.1",
-    "pandapower==2.13.1",
-    "pandas==1.5.3",
-    "numpy==1.26.4",
-    "mosaik>=3.3.3",
-    "ruamel.yaml>= 0.18.5",
+    "arrow>=1.4.0",
+    "lxml>=6.1.1",
+    "matplotlib>=3.10.9",
+    "paho-mqtt>=2.1.0",
+    "pandas>=3.0.3",
+    "numpy>=2.3.5",
+    "mosaik>=3.6.0",
+    "ruamel.yaml>=0.19.1",
     "schema>=0.7.7", 
-    "typer>=0.12.5",
-    "mpi4py"
+    "typer>=0.25.1",
+    "mpi4py>=4.1.2"
 ]
 keywords = [
     "energy",

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,8 @@ and the simulation engine is based on [Mosaik](https://mosaik.offis.de/).
 ## Installation
 
 **Requirements** 
-- Python >= 3.8 & < 3.12
+- Python >= 3.14
+- pandas >= 3.0
 - Miniconda (optional)
 - A Rasberry Pi cluster, for cluster deployment (optional)
 


### PR DESCRIPTION
- Remove 'pandapower' from all dependency files as it is not deemed essential to the project.
- Upgrade Python to >=3.14.5 and pandas to >=3.0.3 across environment.yml, pyproject.toml, and docs/requirements.txt.
- Modernize core libraries including mosaik (>=3.6.0), paho-mqtt (>=2.1.0), and numpy (>=2.3.5).
- Update 'requires-python' in pyproject.toml to >=3.11 to support the new pandas version.
- Verified the stack with the test suite; confirmed Tutorial 1 E2E simulation passes with zero numerical drift.